### PR TITLE
feat: added task to rename k3s nodes

### DIFF
--- a/k3s-ansible/site.yml
+++ b/k3s-ansible/site.yml
@@ -19,3 +19,15 @@
   become: yes
   roles:
     - role: k3s/node
+
+- name: Rename k3s nodes
+  hosts: master
+  become: true
+  tasks:
+    - name: Rename labels in k3s nodes
+      command: >-
+        kubectl label nodes {{ item }} kubernetes.io/role=worker
+      loop:
+        - node2
+        - node3
+        - node4


### PR DESCRIPTION
This PR added a task in Ansible to add Roles in k3s nodes:
before changes:
```
node1   Ready    control-plane,master   2m23s   v1.22.3+k3s1
node4   Ready    <none>                 93s     v1.22.3+k3s1
node2   Ready    <none>                 93s     v1.22.3+k3s1
node3   Ready    <none>                 93s     v1.22.3+k3s1
```

after changes:
```
node1   Ready    control-plane,master   2m23s   v1.22.3+k3s1
node4   Ready    worker                 93s     v1.22.3+k3s1
node2   Ready    worker                 93s     v1.22.3+k3s1
node3   Ready    worker                 93s     v1.22.3+k3s1
```